### PR TITLE
Add reverse-engineered WiFi/UART/cloud protocol documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Reverse-engineering working artifacts (firmware dump, decompilation, J.O.E. app,
+# tooling, untested custom firmware, hardware design) are kept in a separate PRIVATE
+# repo and only published here once verified. Never commit them to this public fork.
+Firmware/
+joe-app/
+custom-firmware/
+hardware/
+*.bin
+*.elf
+*.apk
+.claude/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ For a device to be able to connect to an JURA coffee maker via WiFi, a [WiFi Con
 This adds reverse-engineered documentation of the WiFi Connect dongle's protocols — see
 [`protocol/`](protocol/):
 
+- **Which firmware runs** — the booted image is a **custom JURA LAN app** (no cloud client); a stock
+  **ESP-AT** image is present in flash but **dormant**. ([`protocol/firmware-images.md`](protocol/firmware-images.md))
 - **WiFi LAN control protocol** — the dongle's own TCP/UDP server on port **51515** (`@H…` command set
   + a `*`-prefixed encoded coffee-machine passthrough). Lets the stock dongle be controlled locally,
   no cloud. ([`protocol/wifi-local-protocol.md`](protocol/wifi-local-protocol.md))

--- a/README.md
+++ b/README.md
@@ -9,3 +9,22 @@ For a device to be able to connect to an JURA coffee maker via WiFi, a [WiFi Con
 
 ## Dumping the Firmware
 ![ESP32 inside the WiFi Connect dongle](ressources/images/wifi_dongle_esp32.png)
+
+## Reverse-engineered protocol documentation
+This adds reverse-engineered documentation of the WiFi Connect dongle's protocols — see
+[`protocol/`](protocol/):
+
+- **WiFi LAN control protocol** — the dongle's own TCP/UDP server on port **51515** (`@H…` command set
+  + a `*`-prefixed encoded coffee-machine passthrough). Lets the stock dongle be controlled locally,
+  no cloud. ([`protocol/wifi-local-protocol.md`](protocol/wifi-local-protocol.md))
+- **JURA UART protocol** — 9600 8N1, the keyless 0x5B transfer encoding, V2 handshake + older V1
+  vocabulary. ([`protocol/uart-protocol.md`](protocol/uart-protocol.md))
+- **Cloud architecture** — Keycloak / `joeapi.jura.com` / *pocketpilot*, observed from the J.O.E. app.
+  ([`protocol/cloud-architecture.md`](protocol/cloud-architecture.md))
+
+> ⚠️ **Reverse-engineered from firmware via static analysis — not yet verified on live hardware.**
+> Treat as a working hypothesis until confirmed with a packet/UART capture.
+
+Builds on prior work by Jutta-Proto, [COM8/esp32-jura](https://github.com/COM8/esp32-jura),
+[mkalen/jura-smartconnect-wifi](https://github.com/mkalen/jura-smartconnect-wifi), and
+[juramote](https://6xq.net/juramote/) — see [REFERENCES.md](REFERENCES.md).

--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ This adds reverse-engineered documentation of the WiFi Connect dongle's protocol
 - **Cloud architecture** — Keycloak / `joeapi.jura.com` / *pocketpilot*, observed from the J.O.E. app.
   ([`protocol/cloud-architecture.md`](protocol/cloud-architecture.md))
 
-> ⚠️ **Reverse-engineered from firmware via static analysis — not yet verified on live hardware.**
-> Treat as a working hypothesis until confirmed with a packet/UART capture.
+- **`*`-channel codec** — a compiled, self-testing C++ reference implementation of the WiFi obfuscation
+  (the same shuffle as JURA Bluetooth). ([`src/wifi/ByteEncDecoder.cpp`](src/wifi/ByteEncDecoder.cpp))
+
+> ✅ **The WiFi `@H` LAN protocol is now hardware-verified** (2026-06-06) on a real TT237W dongle —
+> transport, the `@HP:` handshake, the `@H…` identity/version commands, and the `*`-channel obfuscation
+> (decodes captured frames to exact ASCII). Still hypothesis pending a live machine: exact `@HP:` field
+> semantics, `@HR`/`@HB` details, and the live `*` machine command stream. UART/cloud docs remain static analysis.
 
 Builds on prior work by Jutta-Proto, [COM8/esp32-jura](https://github.com/COM8/esp32-jura),
 [mkalen/jura-smartconnect-wifi](https://github.com/mkalen/jura-smartconnect-wifi), and

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,0 +1,25 @@
+# References & credits
+
+This reverse engineering builds directly on prior community work. Huge thanks to:
+
+- **[Jutta-Proto](https://github.com/Jutta-Proto)** — the canonical JURA protocol implementations:
+  - [`protocol-cpp`](https://github.com/Jutta-Proto/protocol-cpp) — UART (V2) + the 0x5B codec.
+  - [`protocol-bt-cpp`](https://github.com/Jutta-Proto/protocol-bt-cpp) — Bluetooth (TT214H), product/brew
+    command structure, statistics, machine-file XML.
+  - [`protocol-wifi-cpp`](https://github.com/Jutta-Proto/protocol-wifi-cpp) — the upstream this repo forks.
+- **[COM8/esp32-jura](https://github.com/COM8/esp32-jura)** — original ESP32 UART + XMPP implementation;
+  the closest existing analog to an ESP32 JURA bridge.
+- **[mkalen/jura-smartconnect-wifi](https://github.com/mkalen/jura-smartconnect-wifi)** — the WiFi Smart
+  Connect UDP discovery layer (TT237W version, machine name, `EF###` type, MAC).
+- **[juramote](https://6xq.net/juramote/)** (PromyLOPh) — the older **V1** machine UART command set.
+- **[Q42 "Hacking the coffee machine"](https://blog.q42.nl/hacking-the-coffee-machine-5802172b17c1)** and
+  the coffeemakers.de forum — early V1 protocol work.
+
+Tooling: [Ghidra](https://ghidra-sre.org/) (Xtensa decompilation), [jadx](https://github.com/skylot/jadx)
+(APK), [esptool](https://github.com/espressif/esptool) (flash I/O),
+[tenable/esp32_image_parser](https://github.com/tenable/esp32_image_parser) (partitions/NVS).
+
+## Scope & ethics
+This is interoperability / repairability research on **own hardware**. No JURA proprietary binaries
+(firmware dump, decompiled firmware, the J.O.E. APK) are published here — only reverse-engineered
+**protocol documentation**, consistent with the prior work above. Licensed GPL-3.0.

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -9,6 +9,7 @@ Reverse-engineered protocols of the JURA WiFi Connect (TT237W) dongle.
 
 | Document | What |
 |----------|------|
+| [`firmware-images.md`](firmware-images.md) | **Read first.** Which of the two firmware images actually boots (a custom JURA LAN app) vs. which is dormant (stock ESP-AT). |
 | [`wifi-local-protocol.md`](wifi-local-protocol.md) | **The headline.** The dongle's LAN control protocol — TCP/UDP **port 51515**, the `@H…` command set, and the `*`-prefixed encoded coffee-machine passthrough. This is how you control the stock dongle locally with no cloud. |
 | [`uart-protocol.md`](uart-protocol.md) | The JURA machine UART protocol the dongle speaks downstream: 9600 8N1, the keyless **0x5B** transfer encoding, V2 handshake, and the older **V1** command vocabulary. |
 | [`cloud-architecture.md`](cloud-architecture.md) | How JURA's cloud is wired (Keycloak / `joeapi.jura.com` / *pocketpilot*) and how the phone app reaches the dongle — context for self-hosting. |
@@ -19,7 +20,7 @@ Reverse-engineered protocols of the JURA WiFi Connect (TT237W) dongle.
                                                             |
                                        LAN: TCP/UDP 51515, @H… + * channel   <-- local control (no cloud)
                                                             |
-                                       WiFi/cloud: ESP-AT + JURA app  <-->  JURA cloud  <-->  J.O.E. phone app
+                                       (running FW = custom JURA app, LAN-only, no cloud client)
 ```
 The dongle is fundamentally a **bridge**: machine-UART on one side, WiFi on the other. The most
 practical local-control path is its **LAN protocol** (`wifi-local-protocol.md`).

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -1,0 +1,25 @@
+# protocol/
+
+Reverse-engineered protocols of the JURA WiFi Connect (TT237W) dongle.
+
+> **⚠️ Reverse-engineered from firmware via static analysis — NOT yet verified on live hardware.**
+> Command names, ports, byte layouts and the codecs below are a working hypothesis recovered by
+> decompiling the dongle firmware and the J.O.E. app. They have **not** been confirmed with a real
+> device/machine yet. Verify against a packet/UART capture before relying on them; corrections welcome.
+
+| Document | What |
+|----------|------|
+| [`wifi-local-protocol.md`](wifi-local-protocol.md) | **The headline.** The dongle's LAN control protocol — TCP/UDP **port 51515**, the `@H…` command set, and the `*`-prefixed encoded coffee-machine passthrough. This is how you control the stock dongle locally with no cloud. |
+| [`uart-protocol.md`](uart-protocol.md) | The JURA machine UART protocol the dongle speaks downstream: 9600 8N1, the keyless **0x5B** transfer encoding, V2 handshake, and the older **V1** command vocabulary. |
+| [`cloud-architecture.md`](cloud-architecture.md) | How JURA's cloud is wired (Keycloak / `joeapi.jura.com` / *pocketpilot*) and how the phone app reaches the dongle — context for self-hosting. |
+
+## The big picture
+```
+   Coffee machine  <--UART 9600 8N1, 0x5B codec-->  [ WiFi Connect dongle (ESP32) ]
+                                                            |
+                                       LAN: TCP/UDP 51515, @H… + * channel   <-- local control (no cloud)
+                                                            |
+                                       WiFi/cloud: ESP-AT + JURA app  <-->  JURA cloud  <-->  J.O.E. phone app
+```
+The dongle is fundamentally a **bridge**: machine-UART on one side, WiFi on the other. The most
+practical local-control path is its **LAN protocol** (`wifi-local-protocol.md`).

--- a/protocol/cloud-architecture.md
+++ b/protocol/cloud-architecture.md
@@ -1,0 +1,32 @@
+# JURA cloud architecture (context for self-hosting)
+
+How the official stack is wired, recovered from the **J.O.E. Android app** (`ch.toptronic.joe`) and the
+dongle firmware. Useful if you want to self-host a replacement server — though the simpler local route is
+the dongle's own LAN protocol (`wifi-local-protocol.md`).
+
+> **⚠️ Observed from the app/firmware; endpoints may change. Not exhaustive.**
+
+## Endpoints (from the J.O.E. app)
+| Purpose | Endpoint |
+|---------|----------|
+| Auth (OIDC) | `https://keycloak.pocketpilot.jura.com/realms/Jura/protocol/openid-connect/{auth,token,…}` |
+| Cloud API | `https://joeapi.jura.com/api/` |
+| Machine list / assets | `https://digitalassets.jura.com/mobileapp/JOE/JOE_MACHINES.TXT` |
+| WiFi onboarding | `jura.com/wifi` |
+
+- Auth is **Keycloak / OpenID Connect**, realm **`Jura`**; JURA's IoT backend is codenamed **pocketpilot**.
+- The modern app is **REST-based** (no XMPP client in the app). The dongle firmware contains an XMPP/TLS
+  client and an ESP-AT OTA path; the cloud bridges the app's REST calls to the dongle.
+
+## What this means
+- The phone app does **not** talk to the dongle directly for cloud control — it goes app → cloud → dongle.
+- But the dongle **also** runs a local LAN server (see `wifi-local-protocol.md`), so for local control you
+  can bypass the cloud entirely.
+- The dongle's cloud credentials (JID/token) are **provisioned at pairing** and are not present in a
+  factory-fresh firmware dump — capturing them (or the LAN protocol) requires a live device.
+
+## Notes on the firmware "cloud" strings
+The dongle firmware's `download_rom` / `+CIPUPDATE` OTA path points at Espressif's demo host
+`iot.espressif.cn` and ships Espressif's **example** TLS CA — i.e. it's largely **stock ESP-AT example
+code**, and that TLS path performs **no certificate verification**. The JURA-specific cloud glue is in the
+application layer, not these ESP-AT leftovers.

--- a/protocol/cloud-architecture.md
+++ b/protocol/cloud-architecture.md
@@ -25,8 +25,11 @@ the dongle's own LAN protocol (`wifi-local-protocol.md`).
 - The dongle's cloud credentials (JID/token) are **provisioned at pairing** and are not present in a
   factory-fresh firmware dump — capturing them (or the LAN protocol) requires a live device.
 
-## Notes on the firmware "cloud" strings
-The dongle firmware's `download_rom` / `+CIPUPDATE` OTA path points at Espressif's demo host
-`iot.espressif.cn` and ships Espressif's **example** TLS CA — i.e. it's largely **stock ESP-AT example
-code**, and that TLS path performs **no certificate verification**. The JURA-specific cloud glue is in the
-application layer, not these ESP-AT leftovers.
+## Important: these cloud/OTA strings are in a DORMANT firmware image
+A stock **ESP-AT** firmware image is present in the dongle's flash (with an XMPP client and a
+`download_rom`/`+CIPUPDATE` OTA path pointing at Espressif's demo host `iot.espressif.cn`, using
+Espressif's **example** TLS CA with **no certificate verification**). **But that image is not booted** —
+the running firmware is a custom JURA app with **no cloud client** (see
+[`firmware-images.md`](firmware-images.md)). So those cloud/OTA/TLS details describe the **dormant**
+image, **not** the live dongle. Earlier notes calling the dongle "ESP-AT based" were reading that
+dormant image.

--- a/protocol/firmware-images.md
+++ b/protocol/firmware-images.md
@@ -1,0 +1,30 @@
+# Firmware images: what actually runs
+
+The dongle's flash contains **two complete, different app firmwares**. Knowing which one boots matters —
+it changes what the dongle actually does.
+
+> **⚠️ Reverse-engineered from a firmware dump; not yet hardware-verified.**
+
+## The two app images
+| Image | Flash offset | Booted? | What it is |
+|-------|-------------|---------|------------|
+| **image-A** | `0x030000` (`ota_0`) | **YES** | A **custom JURA ESP-IDF app**. WiFi + the local `@H…` TCP/UDP control servers + the machine UART. **No XMPP, no cloud client** — it's a LAN device. |
+| **image-B** | `0x100000` | **NO** | A stock **ESP-AT** firmware (XMPP, `+CIPUPDATE`/`download_rom` OTA to `iot.espressif.cn`, example TLS CA). **Dormant — never booted.** |
+
+## Why image-A is the one that runs
+- The partition table (`@0x8000`) places `ota_0` at `0x030000`; `otadata` selects it (seq=1) → the stock
+  2nd-stage bootloader boots **image-A**.
+- image-A is a complete standalone ESP-IDF app (valid entry, FreeRTOS, `esp_wifi`, lwIP, `app_main`).
+
+## Why image-B is dormant
+- image-B (~1.1 MB) physically **overflows the `ota_0` partition** (into the `ota_1` region), so it
+  **cannot be booted via the partition table**.
+- image-A contains **no loader** for it (no reference to offset `0x100000`, no jump to image-B's entry).
+- A 0xFF gap separates the two → independently flashed. image-B sits at **ESP-AT's native `0x100000`
+  app offset**, i.e. it's the module's **original stock ESP-AT firmware**, left in flash when JURA
+  flashed their own app (image-A) and made it the active boot image.
+
+## Consequence
+The live dongle has **no ESP-AT and no cloud client** — it is controlled over the **LAN** via its `@H…`
+protocol (see [`wifi-local-protocol.md`](wifi-local-protocol.md)). Any "ESP-AT / `iot.espressif.cn` /
+no-TLS-verify" observations belong to the **dormant** image-B and do **not** describe the running dongle.

--- a/protocol/uart-protocol.md
+++ b/protocol/uart-protocol.md
@@ -2,7 +2,9 @@
 
 The dongle talks to the coffee machine over the machine's service-port UART. This protocol was
 documented by prior projects — most of this section is **their** work, summarised here for context;
-see credits. The dongle's firmware implements the same scheme (confirmed in decompilation).
+see credits. The running firmware contains a UART driver plus the `TY:`/`@T1` handshake and the 0x5B
+codec (seen in decompilation); higher-level product commands appear to be relayed from the WiFi
+`*`-channel rather than hard-coded. Treat the dongle-specific specifics as unverified.
 
 > **⚠️ The dongle-specific details are reverse-engineered and unverified;** the general JURA UART
 > protocol below is well-established by the cited projects.

--- a/protocol/uart-protocol.md
+++ b/protocol/uart-protocol.md
@@ -1,0 +1,52 @@
+# JURA machine UART protocol (downstream side)
+
+The dongle talks to the coffee machine over the machine's service-port UART. This protocol was
+documented by prior projects — most of this section is **their** work, summarised here for context;
+see credits. The dongle's firmware implements the same scheme (confirmed in decompilation).
+
+> **⚠️ The dongle-specific details are reverse-engineered and unverified;** the general JURA UART
+> protocol below is well-established by the cited projects.
+
+## Line settings
+- **9600 baud, 8 data bits, no parity, 1 stop bit**, no flow control, 5 V TTL.
+- Commands are uppercase ASCII terminated `\r\n`; responses are lowercase; most commands ack with `ok:`.
+
+## The "0x5B" transfer encoding (keyless)
+Every data byte is sent as **4 raw UART bytes** (≈8 ms apart). Each raw byte uses base pattern
+`0b01011011 = 0x5B` and carries only 2 data bits (at bit positions 2 and 5). It is a deterministic
+bit-shuffle, **not** a cipher (no key). Decode reads bytes in groups of 4; partial groups are discarded.
+The exact encode/decode is in [Jutta-Proto/protocol-cpp] (`JuttaConnection.cpp`) and
+[COM8/esp32-jura]; a worked example and captures are in those repos.
+
+```
+encoded byte:  0 1 0 1 1 0 1 1   (0x5B)
+                   ^     ^
+                  bit2  bit5  <- the only data-bearing positions
+```
+
+## Identification & handshake
+- `TY:` → `ty:EF###M Vxx.yy` — the machine **type** (the `EF###` is the machine-file key) + firmware version.
+- Newer (**V2**) machines do a key-exchange before some traffic:
+  `@T1 / @t1 / @T2:… / @t2:… / @T3:…<type> / @t3` (the `@T3` echoes the machine type).
+
+## Command vocabulary
+- **V2 (Jutta-Proto/protocol-cpp):** `AN:` power/mode, `FA:04..09` UI buttons 1–6, `FN:` actuators
+  (pump/heater/grinder/brew-group), product brewing via page+button emulation or a manual actuator
+  sequence. Full table in the cited repos.
+- **V1 (older machines, [juramote]):** richer debug vocabulary — `HZ:` status (temps, flow, brew sensor),
+  `IC:` input board, `RE:`/`RT:` read EEPROM, `WE:` write EEPROM, `DA:`/`DT:`/`DR:` display control,
+  `TY:` type, `GB:` off. Useful for the "older machines only on Bluetooth today" goal.
+
+## Per-machine products
+The J.O.E. app ships per-machine XML (`EF###.xml`) describing each product and its command arguments
+(`F3`=strength, `F4`=water amount, `F7`=temperature, with min/max/step). These map an `EF###` (from
+`TY:`) to the exact brew parameters — the basis for supporting arbitrary machines.
+
+## Credits
+This protocol is documented by [Jutta-Proto/protocol-cpp], [Jutta-Proto/protocol-bt-cpp],
+[COM8/esp32-jura], and [juramote]. See [`../REFERENCES.md`](../REFERENCES.md).
+
+[Jutta-Proto/protocol-cpp]: https://github.com/Jutta-Proto/protocol-cpp
+[Jutta-Proto/protocol-bt-cpp]: https://github.com/Jutta-Proto/protocol-bt-cpp
+[COM8/esp32-jura]: https://github.com/COM8/esp32-jura
+[juramote]: https://6xq.net/juramote/

--- a/protocol/wifi-local-protocol.md
+++ b/protocol/wifi-local-protocol.md
@@ -1,0 +1,65 @@
+# WiFi Connect — local LAN control protocol
+
+How the JURA WiFi Connect dongle is controlled **on the local network**, reverse-engineered from the
+dongle's firmware. This is the basis for cloud-free local control (and matches the discovery layer in
+[mkalen/jura-smartconnect-wifi]).
+
+> **⚠️ Reverse-engineered, not yet hardware-verified.** Confirm against a live capture before relying on
+> exact field orders / the `*`-channel key derivation.
+
+## Transport
+- On start-up the dongle opens **two servers, both on port `0xC93B` = 51515**:
+  - a **TCP** control server (`socket`/`bind`/`listen`/`accept`),
+  - a **UDP** socket used for broadcast **discovery**.
+- It also offers a setup **SoftAP** whose SSID is `"CoffeeMachine_" + <MAC-derived hex> + <XOR-0xFF checksum>`.
+- The protocol is **line-based ASCII, terminated with `\r\n`** (2 KB RX buffer). Responses to `@HX`
+  queries come back lowercase as `@hx:…`. On session close the dongle sends `@TS:00\r\n`.
+
+## Command dispatch
+After each `\r\n`-terminated line the dongle:
+1. If the line starts with **`*`** → routes it to the encoded **coffee-machine passthrough** (below).
+2. Otherwise expects a 4-byte gate command **`@HP:`** first (a handshake/provisioning step); until that
+   succeeds other commands are refused.
+3. Otherwise matches the first 3 characters against a **12-entry command table** and calls the handler.
+
+## Command set — the `@H…` family
+| Command | Meaning (response) |
+|---------|--------------------|
+| `@HI` | identity / signature → `@hi:SIGNATURE…` |
+| `@HL` | loader + module version → `@hl:ESP32LDRSIM TT237W V05.26` |
+| `@HY` | module type/version → `@hy:TT237W V05.26` |
+| `@HW…` | **set WiFi station config** (SSID/credentials → connect) |
+| `@HR<reg>` | **read status register** (e.g. `05` ≈ signal level, `8F` ≈ a custom pin) → `@hr:…` |
+| `@HT<n>` | **control**: `0`/`1` = a GPIO/relay off/on; `2` = disconnect; `3` = **reboot** |
+| `@HP:<f1>,<f2>,…` | **provisioning / gate** (comma-separated fields ≤6 chars) → `@hp4:ok` / `@hp5:` error |
+| `@HU` | **update trigger** → `@hu:000`/status, `@hu:wait`/`@hu:busy`/`@hu:abort` |
+| `@HB` | **discovery/status beacon** (also UDP-broadcasts device info) |
+| `@HO` | **OTA begin** (validate partition, `esp_ota_begin`) → `@ho:ok` / `@ho:error` |
+| `@HD<off><len><hex>` | **OTA data block** (hex-encoded, de-obfuscated, ≤512 B, 4-byte aligned) |
+| `@HE` | **OTA end** (`esp_ota_end` + set boot partition) → `@he:ok` / `@he:error` |
+
+Asynchronous status pushes use `@ha:…` (e.g. `@ha:03,2%01X`, `@ha:05,2`).
+
+## The `*` channel — coffee-machine passthrough
+Lines beginning with `*` carry the **actual machine commands** (brew/status — see `uart-protocol.md`)
+wrapped in a keyed nibble obfuscation:
+- Optional **ESC (`0x1B`) escaping**: a `0x1B` means "clear the high bit of the next byte".
+- The first payload byte's high/low nibbles are the **per-message key** (`k1`, `k2`).
+- Each data byte is split into nibbles; each nibble `x` at position `pos` is decoded as
+  **`out = (x − pos − k1) & 0x0F`** and recombined `hi<<4 | lo`.
+- The decoded bytes are the JURA UART command stream (`TY:`, `FA:`, `FN:`, the `@T1/@T2/@T3` handshake…).
+
+This is distinct from the machine-side 4-bytes-per-byte `0x5B` UART encoding (`uart-protocol.md`); the
+`*` channel is the WiFi transport's own layer on top.
+
+## Using it for local control (untested recipe)
+1. TCP-connect to `dongle_ip:51515`.
+2. Complete the `@HP:` handshake, then `@HY` to identify the module, `@HI`/`@HL` for signature/version.
+3. Set WiFi with `@HW`; read status with `@HR`; reboot with `@HT3`.
+4. Send machine commands over the `*` channel; OTA the dongle with `@HO`/`@HD`/`@HE`.
+
+**Still to confirm on hardware:** exact `@HP:` field order/meaning, the precise `*` key derivation, and
+the UDP discovery payload format. A single Wireshark capture of the J.O.E. app controlling a real dongle
+will nail these down.
+
+[mkalen/jura-smartconnect-wifi]: https://github.com/mkalen/jura-smartconnect-wifi

--- a/protocol/wifi-local-protocol.md
+++ b/protocol/wifi-local-protocol.md
@@ -4,14 +4,17 @@ How the JURA WiFi Connect dongle is controlled **on the local network**, reverse
 dongle's firmware. This is the basis for cloud-free local control (and matches the discovery layer in
 [mkalen/jura-smartconnect-wifi]).
 
-> **⚠️ Reverse-engineered, not yet hardware-verified.** Confirm against a live capture before relying on
-> exact field orders / the `*`-channel key derivation.
+> **✅ Hardware-verified (2026-06-06).** The transport, the `@HP:` handshake, the `@H…` identity/version
+> commands, and the `*`-channel obfuscation are confirmed on a real TT237W dongle. Items still needing a
+> coffee machine attached are called out at the end.
 
 ## Transport
 - On start-up the dongle opens **two servers, both on port `0xC93B` = 51515**:
   - a **TCP** control server (`socket`/`bind`/`listen`/`accept`),
   - a **UDP** socket used for broadcast **discovery**.
-- It also offers a setup **SoftAP** whose SSID is `"CoffeeMachine_" + <MAC-derived hex> + <XOR-0xFF checksum>`.
+- It also offers a setup **SoftAP**. Observed SSID is **`WiFiFrog_<UPPER-HEX-MAC>`** (e.g.
+  `WiFiFrog_3C8A1F18CB19`, AP BSSID = STA MAC + 1), **open** auth, with the dongle as gateway at
+  **`192.168.24.1/24`**. (A `"CoffeeMachine_…"` builder also exists in firmware — model/variant dependent.)
 - The protocol is **line-based ASCII, terminated with `\r\n`** (2 KB RX buffer). Responses to `@HX`
   queries come back lowercase as `@hx:…`. On session close the dongle sends `@TS:00\r\n`.
 
@@ -40,26 +43,58 @@ After each `\r\n`-terminated line the dongle:
 
 Asynchronous status pushes use `@ha:…` (e.g. `@ha:03,2%01X`, `@ha:05,2`).
 
-## The `*` channel — coffee-machine passthrough
+## The `*` channel — coffee-machine passthrough (obfuscation **solved**)
 Lines beginning with `*` carry the **actual machine commands** (brew/status — see `uart-protocol.md`)
-wrapped in a keyed nibble obfuscation:
-- Optional **ESC (`0x1B`) escaping**: a `0x1B` means "clear the high bit of the next byte".
-- The first payload byte's high/low nibbles are the **per-message key** (`k1`, `k2`).
-- Each data byte is split into nibbles; each nibble `x` at position `pos` is decoded as
-  **`out = (x − pos − k1) & 0x0F`** and recombined `hi<<4 | lo`.
-- The decoded bytes are the JURA UART command stream (`TY:`, `FA:`, `FN:`, the `@T1/@T2/@T3` handshake…).
+wrapped in a keyed, position-dependent nibble shuffle. It is the **same algorithm JURA uses on Bluetooth**
+— see [Jutta-Proto/protocol-bt-cpp] `src/bt/ByteEncDecoder.cpp` (`shuffle` / `encDecBytes`); only the
+16-entry S-box tables differ between products. The transform is a **perfect involution** (the same routine
+encodes and decodes).
 
+Frame: `*` + key byte + obfuscated payload + `\r\n`, with optional **ESC (`0x1B`) escaping** (a `0x1B`
+means "clear the high bit of the next byte"; the escape set is `0A 0D 2A 2B 26 1B 00`). The key byte's
+high/low nibbles are `k1`,`k2`. Each plaintext byte is split into nibbles; for nibble `x` at running
+position `pos` (0,1,2,… across the message):
+
+```
+i5 = pos >> 4
+t1 = A[(x  + pos + k1) % 16]
+t2 = B[(t1 + k2  + i5 - pos - k1) % 16]
+t3 = A[(t2 + k1  + pos - k2 - i5) % 16]
+out = (t3 - pos - k1) % 16          # all arithmetic mod 256 then % 16
+```
+
+WiFi-Connect (TT237W) S-box tables, read from the dongle firmware (`A`/`B` for the `*` channel):
+```
+A = [ 1, 0, 3, 2,15,14, 8,10, 6,13, 7,12,11, 9, 5, 4]
+B = [ 9,12, 6,11,10,15, 2,14,13, 0, 4, 3, 1, 8, 7, 5]
+```
+(Two further table pairs exist for other framings; the `*` channel uses the pair above.) Verified: decoding
+a captured `@hy` reply frame yields exactly `@hy:TT237W V05.26`. A small reference implementation with a
+self-test is straightforward to mirror from the BT repo's `ByteEncDecoder` using these tables and the final
+`(t3 - pos - k1)` step.
+
+The decoded bytes are the JURA UART command stream (`TY:`, `FA:`, `FN:`, the `@T1/@T2/@T3` handshake…).
 This is distinct from the machine-side 4-bytes-per-byte `0x5B` UART encoding (`uart-protocol.md`); the
 `*` channel is the WiFi transport's own layer on top.
 
-## Using it for local control (untested recipe)
-1. TCP-connect to `dongle_ip:51515`.
-2. Complete the `@HP:` handshake, then `@HY` to identify the module, `@HI`/`@HL` for signature/version.
-3. Set WiFi with `@HW`; read status with `@HR`; reboot with `@HT3`.
-4. Send machine commands over the `*` channel; OTA the dongle with `@HO`/`@HD`/`@HE`.
+[Jutta-Proto/protocol-bt-cpp]: https://github.com/Jutta-Proto/protocol-bt-cpp
 
-**Still to confirm on hardware:** exact `@HP:` field order/meaning, the precise `*` key derivation, and
-the UDP discovery payload format. A single Wireshark capture of the J.O.E. app controlling a real dongle
-will nail these down.
+## Using it for local control
+1. Join the dongle's open SoftAP (or put it on your LAN); TCP-connect to `dongle_ip:51515`.
+2. Send the **`@HP:` handshake first** (the dispatcher closes the socket otherwise), then `@HY` to
+   identify, `@HI`/`@HL` for signature/version. **Verified replies:** `@HP:0,0,0`→`@hp4`,
+   `@HY`→`@hy:TT237W V05.26`, `@HI`→`@hi:F02371101103F03F`, `@HL`→`@hl:ESP32LDRSIM TT237W V05.26`,
+   `@HU?`→`@hu:800`.
+3. Set WiFi with `@HW`; read status with `@HR`; reboot with `@HT3`.
+4. Send machine commands over the `*` channel (encode/decode with the shuffle above); OTA the dongle with
+   `@HO`/`@HD`/`@HE`.
+
+> **Note on reply encoding:** when no coffee machine is attached the dongle `*`-obfuscates even its `@h…`
+> replies; with a machine present (a "session active" state) it returns them as plain ASCII. Either way,
+> decode with the `*` shuffle above.
+
+**Still needs a coffee machine to confirm:** the exact `@HP:` field semantics, the `@HR` register meanings
+and `@HB` discovery/UDP payload format (both require machine/STA-up state), and the live `*` machine command
+stream. A Wireshark + UART capture of the J.O.E. app driving a real machine will nail these down.
 
 [mkalen/jura-smartconnect-wifi]: https://github.com/mkalen/jura-smartconnect-wifi

--- a/src/wifi/ByteEncDecoder.cpp
+++ b/src/wifi/ByteEncDecoder.cpp
@@ -1,0 +1,108 @@
+#include "wifi/ByteEncDecoder.hpp"
+#include <array>
+#include <cstddef>
+
+//---------------------------------------------------------------------------
+namespace wifi {
+//---------------------------------------------------------------------------
+// WiFi Connect (TT237W) S-boxes for the `*` channel (read from the dongle firmware).
+// Counterparts of protocol-bt-cpp's numbers1/numbers2 — each table is an involution.
+const std::array<uint8_t, 16> numbers1 = {1, 0, 3, 2, 15, 14, 8, 10, 6, 13, 7, 12, 11, 9, 5, 4};
+const std::array<uint8_t, 16> numbers2 = {9, 12, 6, 11, 10, 15, 2, 14, 13, 0, 4, 3, 1, 8, 7, 5};
+
+// Bytes that must be escaped on the wire (a 0x1B prefix, then the byte OR 0x80).
+static bool isEscaped(uint8_t b) {
+    return b == 0x0A || b == 0x0D || b == 0x2A || b == 0x2B || b == 0x26 || b == 0x1B || b == 0x00;
+}
+
+static uint8_t mod16(int i) {
+    return static_cast<uint8_t>(((i % 16) + 16) % 16);
+}
+
+uint8_t shuffle(int dataNibble, int nibbleCount, int keyLeftNibble, int keyRightNibble) {
+    int i5 = (nibbleCount >> 4) & 0xFF;
+    uint8_t t1 = numbers1[mod16(dataNibble + nibbleCount + keyLeftNibble)];
+    uint8_t t2 = numbers2[mod16(t1 + keyRightNibble + i5 - nibbleCount - keyLeftNibble)];
+    uint8_t t3 = numbers1[mod16(t2 + keyLeftNibble + nibbleCount - keyRightNibble - i5)];
+    // Final step (firmware common tail; the part missing from earlier write-ups) makes it an involution.
+    return mod16(t3 - nibbleCount - keyLeftNibble);
+}
+
+std::vector<uint8_t> encDecBytes(const std::vector<uint8_t>& data, uint8_t key) {
+    std::vector<uint8_t> result(data.size());
+    int keyLeftNibble = key >> 4;
+    int keyRightNibble = key & 0x0F;
+    int nibbleCount = 0;
+    for (std::size_t offset = 0; offset < data.size(); ++offset) {
+        uint8_t d = data[offset];
+        uint8_t hi = shuffle(d >> 4, nibbleCount++, keyLeftNibble, keyRightNibble);
+        uint8_t lo = shuffle(d & 0x0F, nibbleCount++, keyLeftNibble, keyRightNibble);
+        result[offset] = static_cast<uint8_t>((hi << 4) | lo);
+    }
+    return result;
+}
+
+std::vector<uint8_t> decodeStarFrame(const std::vector<uint8_t>& frame) {
+    std::vector<uint8_t> out;
+    if (frame.size() < 2) {
+        return out;
+    }
+    std::size_t i = 1;  // skip the leading '*'
+    uint8_t key;
+    if (frame[i] == 0x1B) {
+        ++i;
+        key = frame[i] & 0x7F;
+    } else {
+        key = frame[i];
+    }
+    ++i;
+    int keyLeftNibble = key >> 4;
+    int keyRightNibble = key & 0x0F;
+    int nibbleCount = 0;
+    for (; i < frame.size(); ++i) {
+        uint8_t b = frame[i];
+        if (b == 0x0D) {  // '\r' terminates the payload
+            break;
+        }
+        if (b == 0x1B) {  // ESC: high bit was set on the next byte
+            ++i;
+            b = frame[i] & 0x7F;
+        }
+        uint8_t hi = shuffle(b >> 4, nibbleCount++, keyLeftNibble, keyRightNibble);
+        uint8_t lo = shuffle(b & 0x0F, nibbleCount++, keyLeftNibble, keyRightNibble);
+        out.push_back(static_cast<uint8_t>((hi << 4) | lo));
+    }
+    return out;
+}
+
+std::vector<uint8_t> encodeStarFrame(const std::vector<uint8_t>& plain, uint8_t key) {
+    std::vector<uint8_t> out;
+    out.push_back(0x2A);  // '*'
+    if (isEscaped(key)) {
+        out.push_back(0x1B);
+        out.push_back(key | 0x80);
+    } else {
+        out.push_back(key);
+    }
+    int keyLeftNibble = key >> 4;
+    int keyRightNibble = key & 0x0F;
+    int nibbleCount = 0;
+    for (uint8_t d : plain) {
+        uint8_t hi = shuffle(d >> 4, nibbleCount++, keyLeftNibble, keyRightNibble);
+        uint8_t lo = shuffle(d & 0x0F, nibbleCount++, keyLeftNibble, keyRightNibble);
+        uint8_t enc = static_cast<uint8_t>((hi << 4) | lo);
+        if (isEscaped(enc)) {
+            out.push_back(0x1B);
+            out.push_back(enc | 0x80);
+        } else {
+            out.push_back(enc);
+        }
+    }
+    out.push_back(0x0D);
+    out.push_back(0x0A);
+    return out;
+}
+
+//---------------------------------------------------------------------------
+}  // namespace wifi
+//---------------------------------------------------------------------------

--- a/src/wifi/ByteEncDecoder.hpp
+++ b/src/wifi/ByteEncDecoder.hpp
@@ -1,0 +1,34 @@
+#pragma once
+//---------------------------------------------------------------------------
+// JURA WiFi Connect (TT237W "WiFiFrog") `*`-channel obfuscation codec.
+//
+// This is the SAME keyed nibble shuffle JURA uses on Bluetooth — see
+// Jutta-Proto/protocol-bt-cpp `src/bt/ByteEncDecoder.cpp` (bt::shuffle / bt::encDecBytes).
+// Only the 16-entry S-box tables differ between products. The shuffle is an involution
+// (the same routine both encodes and decodes). See protocol/wifi-local-protocol.md.
+//---------------------------------------------------------------------------
+#include <cstdint>
+#include <vector>
+
+namespace wifi {
+//---------------------------------------------------------------------------
+
+/// Keyed, position-dependent nibble involution. `nibbleCount` is the running nibble
+/// index across the message (0,1,2,…); `keyLeftNibble`/`keyRightNibble` are the high/low
+/// nibbles of the per-message key byte. Mirrors bt::shuffle with the WiFi S-boxes.
+uint8_t shuffle(int dataNibble, int nibbleCount, int keyLeftNibble, int keyRightNibble);
+
+/// Encode OR decode a flat byte buffer (same routine both ways), as used inside a frame.
+/// `key` is the per-message key byte (its nibbles drive the shuffle).
+std::vector<uint8_t> encDecBytes(const std::vector<uint8_t>& data, uint8_t key);
+
+/// Decode a full on-the-wire `*`-frame ("*" + key + obfuscated payload + "\r\n",
+/// with 0x1B high-bit escaping) into the plaintext payload.
+std::vector<uint8_t> decodeStarFrame(const std::vector<uint8_t>& frame);
+
+/// Build a `*`-frame for `plain` using key byte `key` (the real firmware randomizes it).
+std::vector<uint8_t> encodeStarFrame(const std::vector<uint8_t>& plain, uint8_t key);
+
+//---------------------------------------------------------------------------
+}  // namespace wifi
+//---------------------------------------------------------------------------

--- a/src/wifi/ByteEncDecoder_test.cpp
+++ b/src/wifi/ByteEncDecoder_test.cpp
@@ -1,0 +1,46 @@
+// Self-test for wifi::ByteEncDecoder — decodes real captured *-frames to exact ASCII
+// and checks the shuffle is a perfect involution.
+//
+//   g++ -std=c++17 -I. wifi/ByteEncDecoder.cpp wifi/ByteEncDecoder_test.cpp -o codec_test && ./codec_test
+//
+#include "wifi/ByteEncDecoder.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+static std::vector<uint8_t> H(std::initializer_list<int> b) { return {b.begin(), b.end()}; }
+static std::string S(const std::vector<uint8_t>& v) { return std::string(v.begin(), v.end()); }
+
+int main() {
+    int fails = 0;
+
+    // 1) involution: decode(encode(x)) == x for all nibbles / positions / keys
+    for (int k1 = 0; k1 < 16; ++k1)
+        for (int k2 = 0; k2 < 16; ++k2)
+            for (int pos = 0; pos < 60; ++pos)
+                for (int x = 0; x < 16; ++x)
+                    if (wifi::shuffle(wifi::shuffle(x, pos, k1, k2), pos, k1, k2) != x) ++fails;
+    std::printf("involution: %s\n", fails == 0 ? "OK" : "FAIL");
+
+    // 2) real captured frames (dongle replies, see protocol/wifi-local-protocol.md)
+    struct Case { std::vector<uint8_t> frame; std::string want; };
+    std::vector<Case> cases = {
+        {H({0x2a,0x12,0xea,0x0f,0xcf,0x56,0x4b,0x44,0x0d,0x0a}), "@hp4\r\n"},
+        {H({0x2a,0x69,0xad,0x84,0xec,0x8b,0xbb,0xe6,0x4c,0xdc,0x1b,0x80,0x85,0x84,0x19,0x08,
+            0xa1,0x67,0xec,0xa8,0x1a,0x1f,0x0d,0x0a}), "@hy:TT237W V05.26\r\n"},
+        {H({0x2a,0xeb,0xda,0x1e,0x9a,0xa0,0x59,0xdf,0xb5,0xfd,0xfd,0xa3,0x90,0x69,0xb4,0x8b,
+            0x1e,0x88,0xbd,0x85,0xcf,0xff,0xc2,0xb3,0x53,0x0b,0xfc,0xc2,0x83,0xde,0x4c,0x49,
+            0xa2,0x0d,0x0a}), "@hl:ESP32LDRSIM TT237W V05.26\r\n"},
+    };
+    for (auto& c : cases) {
+        std::string got = S(wifi::decodeStarFrame(c.frame));
+        bool ok = got == c.want;
+        fails += !ok;
+        std::printf("  %s decode -> \"%s\"\n", ok ? "OK  " : "FAIL", got.c_str());
+    }
+
+    std::printf("%s\n", fails == 0 ? "ALL PASS" : "FAILURES");
+    return fails == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What this adds

Reverse-engineered documentation of the **JURA WiFi Connect (TT237W)** dongle's protocols, under a new
[`protocol/`](protocol/) folder:

- **WiFi LAN control protocol** — the dongle runs its own **TCP + UDP server on port 51515** speaking a
  line-based `@H…` command set (`@HI/@HL/@HY/@HW/@HR/@HT/@HP/@HU/@HB/@HO/@HD/@HE`), with the actual
  machine commands tunnelled over a `*`-prefixed keyed-nibble channel. This means the **stock dongle can
  be controlled locally over the LAN, with no cloud.** Onboarding SoftAP SSID is `CoffeeMachine_<id>`.
- **JURA UART protocol** — 9600 8N1, the keyless **0x5B** 4-bytes-per-byte transfer encoding, the V2
  `@T1/@T2/@T3` handshake, and the older **V1** command vocabulary (`HZ:`/`RE:`/`WE:`/…). Largely your
  prior work, summarised for context with full credit.
- **Cloud architecture** — Keycloak (`keycloak.pocketpilot.jura.com`, realm `Jura`), `joeapi.jura.com`,
  and the *pocketpilot* backend, observed from the J.O.E. app; plus the finding that the firmware's
  `+CIPUPDATE`/`download_rom` path is stock ESP-AT example code pointing at `iot.espressif.cn` with no
  TLS cert verification.

## How it was derived

Static analysis (Ghidra/Xtensa) of a dongle's firmware dump and decompilation of the J.O.E. Android app.

> ⚠️ **Not yet verified on live hardware** (no compatible machine on hand). Everything is clearly labeled
> as a reverse-engineered working hypothesis — please treat it as such until confirmed with a
> packet/UART capture. Corrections very welcome.

## Notes

- **Documentation only** — no JURA proprietary binaries (firmware dump, decompiled firmware, or the
  J.O.E. APK) are included.
- Builds on and credits Jutta-Proto, COM8/esp32-jura, mkalen/jura-smartconnect-wifi, and juramote
  (see `REFERENCES.md`).
- The README gets one added "Reverse-engineered protocol documentation" section; existing content is
  untouched.
